### PR TITLE
Did some adjustments to question-yon.js

### DIFF
--- a/functions/detections/question-yon.js
+++ b/functions/detections/question-yon.js
@@ -1,6 +1,6 @@
 module.exports = (msc, author) => {
     var detections = [" do ", ' are ', ' does ', ' is ', ' has ', ' can we ', ' can you ', ' can i ', ' am i ', ' am ', ' im ', "?"]
-    var replies = [`${msc}`,'no way','nahhh',`yeah ${author}`, 'yes', 'nah','no', 'idk', 'maybe?', 'definitely', 'https://cdn.discordapp.com/attachments/1009383133726130216/1043821892102012938/trim.9B58117E-87CA-4B8F-A6AE-DEE69B944AC0.mov']
+    var replies = [`${msc}`, 'yes', 'nah','no', 'idk', 'maybe?', 'definitely', 'https://cdn.discordapp.com/attachments/1009383133726130216/1043821892102012938/trim.9B58117E-87CA-4B8F-A6AE-DEE69B944AC0.mov']
     var reply = replies[Math.floor(Math.random() * replies.length)]
     var donejson = {
         detections:detections, 


### PR DESCRIPTION
Why does "no way", "nahhh", and "yeah ${author}" needs to be added to this file if theres already "nah", "no", and "yes". Those are the words a person would answer to a question. not "no way", "nahhh", and "yeah ${author}".